### PR TITLE
simplify build using cmake and update to re2c 4.4

### DIFF
--- a/.ci_support/win_64_.yaml
+++ b/.ci_support/win_64_.yaml
@@ -1,18 +1,12 @@
+c_compiler:
+- vs2022
+c_stdlib:
+- vs
 channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
-m2w64_c_compiler:
-- gcc
-m2w64_c_compiler_version:
-- '14'
-m2w64_c_stdlib:
-- m2w64-sysroot
-m2w64_c_stdlib_version:
-- '12'
-m2w64_cxx_compiler:
-- gxx
-m2w64_cxx_compiler_version:
-- '14'
+cxx_compiler:
+- vs2022
 target_platform:
 - win-64

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Home: http://re2c.org
 
 Package license: Public Domain
 
-Summary: Lexer generator for C/C++ 
+Summary: Lexer generator for C/C++
 
 Development: https://github.com/skvadrik/re2c
 

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -6,5 +6,8 @@ if errorlevel 1 exit 1
 cmake --build build
 if errorlevel 1 exit 1
 
+ctest --test-dir build --output-on-failure
+if errorlevel 1 exit 1
+
 cmake --build build --target install
 if errorlevel 1 exit 1

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -1,7 +1,10 @@
-copy "%RECIPE_DIR%\build.sh" .
-set MSYSTEM=MINGW%ARCH%
-set MSYS2_PATH_TYPE=inherit
-set CHERE_INVOKING=1
-FOR /F "delims=" %%i in ('cygpath.exe -u "%LIBRARY_PREFIX%"') DO set "PREFIX=%%i"
-bash -lce "./build.sh"
+echo ON
+
+cmake %CMAKE_ARGS% -G Ninja -S . -B build
+if errorlevel 1 exit 1
+
+cmake --build build
+if errorlevel 1 exit 1
+
+cmake --build build --target install
 if errorlevel 1 exit 1

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -4,4 +4,5 @@ set -ex
 
 cmake ${CMAKE_ARGS} -DCMAKE_BUILD_TYPE=Release -G Ninja -S . -B build
 cmake --build build
+ctest --test-dir build --output-on-failure
 cmake --build build --target install

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,9 +1,7 @@
 #!/bin/bash
-# Get an updated config.sub and config.guess
-cp $BUILD_PREFIX/share/gnuconfig/config.* ./build-aux
+
 set -ex
-./configure --prefix=${PREFIX}
-make -j${CPU_COUNT}
-# Fails on Windows:
-#make check || (cat test-suite.log && exit 1)
-make install
+
+cmake ${CMAKE_ARGS} -DCMAKE_BUILD_TYPE=Release -G Ninja -S . -B build
+cmake --build build
+cmake --build build --target install

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,9 +1,8 @@
 {% set name = "re2c" %}
 {% set version = "4.4" %}
-{% set posix = 'm2-' if win else '' %}
 
 package:
-  name: {{ name|lower }}
+  name: {{ name }}
   version: {{ version }}
 
 source:
@@ -11,19 +10,15 @@ source:
   sha256: 6b6b865924447ef992d5db4e52fb9307e5f65f26edd43efa91395da810f4280a
 
 build:
-  number: 0
+  number: 1
 
 requirements:
   build:
-    - gnuconfig  # [unix]
-    - {{ compiler('c') }}           # [unix]
-    - {{ stdlib("c") }}             # [unix]
-    - {{ compiler('cxx') }}         # [unix]
-    - {{ compiler('m2w64_c') }}     # [win]
-    - {{ stdlib("m2w64_c") }}       # [win]
-    - {{ compiler('m2w64_cxx') }}   # [win]
-    - {{ posix }}make
-    - m2-base                         # [win]
+    - cmake
+    - ninja
+    - {{ compiler('c') }}
+    - {{ stdlib("c") }}
+    - {{ compiler('cxx') }}
 
 test:
   commands:
@@ -34,7 +29,7 @@ about:
   license: Public Domain
   license_family: PUBLIC-DOMAIN
   license_file: LICENSE
-  summary: 'Lexer generator for C/C++ '
+  summary: 'Lexer generator for C/C++'
   doc_url: http://re2c.org/manual/manual.html
   dev_url: https://github.com/skvadrik/re2c
 


### PR DESCRIPTION
Re2c should build fine with cmake on linux/macos/windows using the native compilers. The PR should simplify the build logic a lot.

I opened this PR because the windows version is no longer working.

The PR also updates to the latest re2c version.

I think this is ready to merge.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
