### PR TITLE
execute test target instead of calling ctest

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -6,7 +6,7 @@ if errorlevel 1 exit 1
 cmake --build build
 if errorlevel 1 exit 1
 
-ctest --test-dir build --output-on-failure
+cmake --build build --target check_re2c
 if errorlevel 1 exit 1
 
 cmake --build build --target install

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -4,5 +4,7 @@ set -ex
 
 cmake ${CMAKE_ARGS} -DCMAKE_BUILD_TYPE=Release -G Ninja -S . -B build
 cmake --build build
-cmake --build build --target check_re2c
+if [[ "$HOST" != arm64-apple* ]]; then
+    cmake --build build --target check_re2c
+fi
 cmake --build build --target install

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -4,5 +4,5 @@ set -ex
 
 cmake ${CMAKE_ARGS} -DCMAKE_BUILD_TYPE=Release -G Ninja -S . -B build
 cmake --build build
-ctest --test-dir build --output-on-failure
+cmake --build build --target check_re2c
 cmake --build build --target install

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,6 +16,9 @@ requirements:
   build:
     - cmake
     - ninja
+    - python
+    - diffutils  # [not win]
+    - m2-diffutils  # [win]
     - {{ compiler('c') }}
     - {{ stdlib("c") }}
     - {{ compiler('cxx') }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 6b6b865924447ef992d5db4e52fb9307e5f65f26edd43efa91395da810f4280a
 
 build:
-  number: 1
+  number: 2
 
 requirements:
   build:


### PR DESCRIPTION
re2c does not use ctest integration but provides a custom test target called: check_re2c.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
